### PR TITLE
ci: only build pushes on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+# Pushes are only built on main. A branch with an open pull request would otherwise
+# run the whole matrix twice: once for the push event and once for the pull_request.
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Halves CI cost per pull request. No product change.

`on: [push, pull_request]` fires twice for any branch that has an open pull request — once for the `push` event, once for the `pull_request` event — so every PR ran the entire Node matrix two times over.

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

Branch commits stay covered by the `pull_request` event, and `main` still gets its post-merge run. `pull_request` is deliberately left unscoped, so a PR targeting any base branch is still built.

This PR is its own proof: it should show half the checks the previous ones did.